### PR TITLE
New Feature: Allow the user to set the manifest entry key for version.

### DIFF
--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -100,10 +100,11 @@
 ;; Middleware
 (defn version-from-scm
   [project]
-  (let [v (str (or (version (:v project)) "UNKNOWN"))]
+  (let [v (str (or (version (:v project)) "UNKNOWN"))
+        vk (str (or (:manifest-version-name (:v project)) "Implementation-Version"))]
     (-> project
        (assoc-in [:version] v)
-       (assoc-in [:manifest "Implementation-Version"] v))))
+       (assoc-in [:manifest vk] v))))
 
 (defn add-workspace-data
   [project]

--- a/test/integration/lein_v/plugin.clj
+++ b/test/integration/lein_v/plugin.clj
@@ -32,6 +32,12 @@
   => (contains {:version "2.3.4-alpha4"
                :manifest (contains {"Implementation-Version" "2.3.4-alpha4"})}))
 
+(fact "Commit with zero commit distance yields simple version on different manifest entry key"
+  (against-background (before :facts (do (clone! "test1.repo"))))
+  (middleware (assoc-in $mproject [:v :manifest-version-name] "Specification-Version"))
+  => (contains {:version "2.3.4-alpha4"
+                :manifest (contains {"Specification-Version" "2.3.4-alpha4"})}))
+
 (fact "Commit with positive commit distance yields complete version"
   (against-background (before :facts (do (clone! "test1.repo") (commit!))))
   (middleware $mproject)


### PR DESCRIPTION
Hi!  I really like lein-v so far but my org uses the "Specification-Version" entry key in the manifest for tracking software versions.  This pull request contains an implementation of an optional way to specify what key the user would like to store the version under.  I've preserved the original behavior as the default if the user doesn't specify.