### PR TITLE
Add the ability to compute dependency versions (in a monorepo situation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml
 pom.xml.asc
 .lein-repl-history
 .nrepl-port
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ pom.xml
 pom.xml.asc
 .lein-repl-history
 .nrepl-port
-/.idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,40 @@ becomes this:
 
 Assuming that there is a git tag `v1.0.1` on the commit `HEAD~~`, and that the SHA of `HEAD` is uniquely identified by `abcd`.  This behavior is automatically enabled whenever lein-v finds the project version to be the keyword `:lein-v`.
 
+## Dependencies
+
+In case you're using a monorepository, you could also use lein-v to determine the current version of dependencies.
+
+Add the `leiningen.v/dependency-version-from-scm` middleware to your project like this:
+
+```
+  :middleware [leiningen.v/version-from-scm
+               leiningen.v/dependency-version-from-scm
+               leiningen.v/add-workspace-data]
+```
+
+Now, if you set the version of a dependency from your monorepo to nil (just as you would using managed-dependencies), it will be replaced
+with the current version from git (which is the same as the version of the project you're currently working on).
+
+```
+  :dependencies
+  [[commons-io "2.5"]
+   [example/lib-a nil]
+   [example/lib-b nil]
+   [org.clojure/clojure "1.8.0"]])
+```
+
+becomes
+
+```
+  :dependencies
+  [[commons-io "2.5"]
+   [example/lib-a "1.0.1-2-0xabcd"]
+   [example/lib-b "1.0.1-2-0xabcd"]
+   [org.clojure/clojure "1.8.0"]])
+```
+
+
 ## Support for lein release ##
 As of version 5.0, lein-v adds support for leiningen's `release` task.  Specifically, the `lein v update` task can anchor a release process that ensures that git tags are created and pushed, and that those tags conform to sane versioning expectations.  To use `lein release` with lein-v, first modify `project.clj` (or your leiningen user profile) as follows:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The lein-v plugin was driven by several beliefs:
 	1. Versioning should be painless in the simplest cases
 	2. Unique (and reproducible/commited) source should produce unique versions
 	3. Versioning information should live in the SCM repo -the source of source truth
-	4. Version information is metadata and should not be stored within with the data it describes
+	4. Version information is metadata and should not be stored within the data it describes
 
 Lein-v uses git metadata to build a unique, reproducible and semantically meaningful version for every commit.  Along the way, it adds useful metadata to your project and artifacts (jar and war files) to tie them back to a specific commit.  Finally, it helps ensure that you never release an irreproduceable artifact.
 
@@ -16,10 +16,10 @@ Lein-v uses git metadata to build a unique, reproducible and semantically meanin
 
 There are two lein sub-tasks within the v namespace intended for direct use:
 
-###lein v show
+### lein v show
 Show the effective version of the project and workspace state.
 
-###lein v cache
+### lein v cache
 Cache the effective version of the project to a file (default is `version.clj`) in the first source directory (typically `src`).  It is possible to have the version cached to a file automatically by defining a prep task in your project:
 
     :prep-tasks [["v" "cache" "src"]]
@@ -41,7 +41,7 @@ becomes this:
 Assuming that there is a git tag `v1.0.1` on the commit `HEAD~~`, and that the SHA of `HEAD` is uniquely identified by `abcd`.  This behavior is automatically enabled whenever lein-v finds the project version to be the keyword `:lein-v`.
 
 ## Support for lein release ##
-As of version 5.0, lein-v adds support for leiningen's `release` task.  Specifically, the `lein v update` task can anchor a release process that ensures that git tags are created and pushed, and that those tags conform to sane versioning expectations.  To use `lein release` with lein-v, first modify `project.clj` (or your leiningein user profile) as follows:
+As of version 5.0, lein-v adds support for leiningen's `release` task.  Specifically, the `lein v update` task can anchor a release process that ensures that git tags are created and pushed, and that those tags conform to sane versioning expectations.  To use `lein release` with lein-v, first modify `project.clj` (or your leiningen user profile) as follows:
 
     :release-tasks [["vcs" "assert-committed"]
                     ["v" "update"] ;; compute new version & tag it
@@ -100,7 +100,7 @@ HEAD to the most recent version tag (looking towards the root of the tree) and t
 It is still possible to do a raw `lein deploy`, in which case the version will be that determined by
 lein-v (most likely something like "1.0.1-2-0xabcd").
 
-Note: you can provide your own implementation of many of these rules.  See the source code for details on defining data types adhering to the protocols in the `leiningein.v.protocols` namespace.  Currently there are implementations for maven (version 3) and Semantic Versioning (version 2) available.
+Note: you can provide your own implementation of many of these rules.  See the source code for details on defining data types adhering to the protocols in the `leiningen.v.protocols` namespace.  Currently there are implementations for maven (version 3) and Semantic Versioning (version 2) available.
 
 ### References and Relevant Reading ###
 

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.apache.maven/maven-artifact "3.3.9"]]
   :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.2.1"]]
                    :eastwood {:config-files []
                               :exclude-linters []
                               ;:add-linters [:unused-namespaces]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.roomkey/lein-v :lein-v
+(defproject com.roomkey/lein-v "0.0.0"
   :description "A Leiningen plugin to reflect on the SCM workspace of a project"
   :url "https://github.com/roomkey/lein-v"
   :release-tasks [["v" "assert-anchored"]

--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -111,18 +111,12 @@
     (assoc d 1 v)
     d))
 
-; => (update-dependency "42" ["abc" "1.0"])
-; ["abc" "1.0"]
-; => (update-dependency "42" ["abc" (quote lein-v)])
-; ["abc" "42"]
-
-
 (defn dependency-version-from-scm
   [project]
   (let [v (str (or (version (:v project)) "UNKNOWN"))]
-    (update project
-            :dependencies
-            #(map (partial update-dependency v) %1))))
+    (clojure.core/update project
+                         :dependencies
+                         #(map (partial update-dependency v) %1))))
 
 (defn add-workspace-data
   [project]

--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -119,18 +119,17 @@
 
 (defn dependency-version-from-scm
   [project]
-  (let [v (str (or (version (:v project)) "UNKNOWN"))
-        vk (str (or (:manifest-version-name (:v project)) "Implementation-Version"))]
-    (update-in project
-               [:dependencies]
-               #(map (partial update-dependency v) %1))))
+  (let [v (str (or (version (:v project)) "UNKNOWN"))]
+    (update project
+            :dependencies
+            #(map (partial update-dependency v) %1))))
 
 (defn add-workspace-data
   [project]
   (if-let [wss (workspace-state project)]
     (-> project
-        (assoc-in,, [:workspace] wss)
-        (assoc-in,, [:manifest "Workspace-Description"] (:describe wss))
-        (assoc-in,, [:manifest "Workspace-Tracking-Status"] (string/join " || " (get-in wss [:status :tracking])))
-        (assoc-in,, [:manifest "Workspace-File-Status"] (string/join " || " (get-in wss [:status :files]))))
+        (assoc-in [:workspace] wss)
+        (assoc-in [:manifest "Workspace-Description"] (:describe wss))
+        (assoc-in [:manifest "Workspace-Tracking-Status"] (string/join " || " (get-in wss [:status :tracking])))
+        (assoc-in [:manifest "Workspace-File-Status"] (string/join " || " (get-in wss [:status :files]))))
     project))


### PR DESCRIPTION
In a monorepository, I'd like to share the same version (derived from git tags) in all projects, i.e. apps and libs respectively. Therefore, I not only need to compute the project version, but also compute the version of the dependencies in a given project.

Using the new middleware `leiningen.v/dependency-version-from-scm`, you can achive this by a nil-dependency version, just like managed-dependencies are handling this.

I wasn't able to get the tests up and running (before my change), but I got an example repo here, if you'd like to check: [example of my lein-monolith fork](https://github.com/chrisbetz/lein-monolith/tree/master/example). Just run `lein monolith each do clean, install` in the example-folder to check.

I'd really much appreciate any comments or a merge :)

Cheers,

Chris