### PR TITLE
add the ability to run builds on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: clojure
+jdk:
+  - oraclejdk8
+
+script: "lein do clean, check, midje"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Drive leiningen project version from git instead of the other way around.
 
+[![Build Status](https://secure.travis-ci.org/com.roomkey/lein-v.png)](http://travis-ci.org/com.roomkey/lein-v)
+
 ## Motivation ##
 The lein-v plugin was driven by several beliefs:
 
@@ -122,6 +124,6 @@ Note: you can provide your own implementation of many of these rules.  See the s
 
 ## License ##
 
-Copyright (C) 2016 Room Key
+Copyright (C) 2017 Room Key
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.apache.maven/maven-artifact "3.3.9"]]
   :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.2.1"]]
                    :eastwood {:config-files []
                               :exclude-linters []
                               ;:add-linters [:unused-namespaces]


### PR DESCRIPTION
This PR simply adds a .travis.yml file to be able to run CI builds on TravisCI. You might want to check it out on https://travis-ci.org/chrisbetz/lein-v. Once you merged you will be able to sign up to travis and activate the lein-v repository for building. After that, any push will trigger a build and the README now contains a badge to show the status of the build (which already targets your expected CI config and not mine).

(Hope you don't mind the update of the update of you copyright, needed any change to trigger a build before I squashed the commits.)