### PR TITLE
ability to run builds on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: clojure
+jdk:
+  - oraclejdk8
+
+script: "lein do clean, check, midje"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Drive leiningen project version from git instead of the other way around.
 
+[![Build Status](https://secure.travis-ci.org/com.roomkey/lein-v.png)](http://travis-ci.org/com.roomkey/lein-v)
+
 ## Motivation ##
 The lein-v plugin was driven by several beliefs:
 
@@ -122,6 +124,6 @@ Note: you can provide your own implementation of many of these rules.  See the s
 
 ## License ##
 
-Copyright (C) 2016 Room Key
+Copyright (C) 2017 Room Key
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.apache.maven/maven-artifact "3.3.9"]]
   :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.2.1"]]
                    :eastwood {:config-files []
                               :exclude-linters []
                               ;:add-linters [:unused-namespaces]


### PR DESCRIPTION
- added .travis.yml configuring the build
- added lein-midje plugin to project so travis has all the required dependencies to check, build and test.
- updated README to show a build badge as soon as Travis is configured

(this replaces PR #9)