### PR TITLE
Add a version.edn cache along version.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :jvm-opts ["-Djava.io.tmpdir=./tmp"]
-  :repositories [["rk-public" {:url "http://rk-maven-public.s3-website-us-east-1.amazonaws.com/releases/"}]
-                 ["rk-private" {:url "s3://rk-maven/releases/"}]]
+  ;;:repositories [["rk-public" {:url "https://rk-maven-public.s3-website-us-east-1.amazonaws.com/releases/"}]
+                 ;;["rk-private" {:url "s3://rk-maven/releases/"}]]
   :eval-in-leiningen true)

--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -27,7 +27,9 @@
   "Cache the effective version for use outside the scope of leiningen evaluation"
   [project & [dir]]
   (let [{{describe :describe} :workspace :keys [version source-paths]} project
-        path (str (or dir (first source-paths)) "/version.clj")]
+        path (str (or dir (first source-paths)) "/version.clj")
+        path-edn (str (or dir (first source-paths)) "/version.edn")]
+    (file/cache-edn path-edn version describe)
     (file/cache path version describe)))
 
 (defn- update*

--- a/src/leiningen/v/file.clj
+++ b/src/leiningen/v/file.clj
@@ -10,6 +10,14 @@
                      (format "(def raw-version \"%s\")" describe)
                      ""]))
 
+(defn- cache-edn-source
+  "return EDN data structure for the version cache EDN file"
+  [version describe]
+  (string/join "{"
+               (format ":version \"%s\"" version)
+               (format ":raw-version \"%s\"" describe)
+               "}"))
+
 (defn version
   "Peek into the source of the project to read the cached version"
   [file]
@@ -22,3 +30,7 @@
   "Write the version of the given Leiningen project to a file-backed cache"
   [path version describe]
   (spit path (cache-source version describe)))
+
+(defn cache-edn
+  [path version describe]
+  (spit path (cache-edn-source version describe)))

--- a/src/leiningen/v/file.clj
+++ b/src/leiningen/v/file.clj
@@ -13,10 +13,10 @@
 (defn- cache-edn-source
   "return EDN data structure for the version cache EDN file"
   [version describe]
-  (string/join "{"
-               (format ":version \"%s\"" version)
-               (format ":raw-version \"%s\"" describe)
-               "}"))
+  (string/join "\n"[ "{"
+                    (format ":version \"%s\"" version)
+                    (format ":raw-version \"%s\"" describe)
+                    "}"]))
 
 (defn version
   "Peek into the source of the project to read the cached version"

--- a/src/leiningen/v/file.clj
+++ b/src/leiningen/v/file.clj
@@ -13,10 +13,8 @@
 (defn- cache-edn-source
   "return EDN data structure for the version cache EDN file"
   [version describe]
-  (string/join "\n"[ "{"
-                    (format ":version \"%s\"" version)
-                    (format ":raw-version \"%s\"" describe)
-                    "}"]))
+  (pr-str  {:version version
+            :raw-version describe}))
 
 (defn version
   "Peek into the source of the project to read the cached version"

--- a/test/integration/leiningen/v.clj
+++ b/test/integration/leiningen/v.clj
@@ -22,7 +22,7 @@
   (against-background (before :facts (do (clone! "test0.repo") (commit!))))
   (v (version-from-scm $mproject) "cache") => anything
   (provided
-    (spit "/X/version.clj" (as-checker (partial re-find #"1.2.3-1-0x[0-9a-f]{4,}"))) => ..result..))
+    (spit #"/X/version.(clj|edn)" (as-checker (partial re-find #"1.2.3-1-0x[0-9a-f]{4,}"))) => ..result..))
 
 (fact "update task works"
   (against-background (before :facts (do (clone! "test0.repo") (commit!))))

--- a/test/unit/leiningen/v/file.clj
+++ b/test/unit/leiningen/v/file.clj
@@ -9,7 +9,19 @@
   (and (= "..version.." (eval 'version/version))
        (= "..describe.." (eval 'version/raw-version))))
 
+
+(defchecker valid-version-data-structure
+  [actual]
+  (let [version-edn (load-string actual)]
+    (and (= "..version.." (:version version-edn))
+         (= "..describe.." (:raw-version version-edn)))))
+
 (fact "Version source code is cached"
   (cache ..path.. ..version.. ..describe..) => anything
   (provided
     (clojure.core/spit ..path.. valid-version-source) => ..ignored..))
+
+(fact "Version data structure is cached"
+      (cache-edn ..path.. ..version.. ..describe..) => anything
+      (provided
+       (clojure.core/spit ..path.. valid-version-data-structure) => ..ignored..))


### PR DESCRIPTION
My use case is to be able to `slurp` the file `version.edn` in project.clj with a simple 
```
~(str (:version (clojure.edn/read-string (slurp "src/version.edn"))))
```
to include the version in any filename produced.