### PR TITLE
Windows compatibility code

### DIFF
--- a/src/leiningen/v/git.clj
+++ b/src/leiningen/v/git.clj
@@ -7,31 +7,30 @@
 (def ^:dynamic *min-sha-length* 4)
 (def ^:dynamic *dirty-mark* "DIRTY")
 
-(def unix-prefix ["/bin/bash" "-c"])
+(def unix-git-command "git")
 
 (def ^:private windows?
   (memoize (fn [] (some-> (System/getProperty "os.name")
                           (.startsWith "Windows")))))
 
-(defn- find-windows-git
-  []
-  (let [{:keys [exit out err]} (shell/sh "where" "git.exe")]
-    (if-not (zero? exit)
-      (lein/abort (format (str "Can't determine location of git.exe: 'where git.exe' returned %d.\n"
-                               "stdout: %s\n stderr: %s")
-                          exit out err))
-      (string/trim out))))
+(def ^:private find-windows-git
+  (memoize
+    (fn []
+      (let [{:keys [exit out err]} (shell/sh "where" "git.exe")]
+        (if-not (zero? exit)
+          (lein/abort (format (str "Can't determine location of git.exe: 'where git.exe' returned %d.\n"
+                                   "stdout: %s\n stderr: %s")
+                              exit out err))
+          (string/trim out))))))
 
-(defn- command-line
-  [command]
+(defn- git-exe []
   (if (windows?)
-    (concat [(find-windows-git)] (string/split command #" +"))
-    (concat unix-prefix [(str "git " command)])))
+    (find-windows-git)
+    unix-git-command))
 
 (defn- git-command
-  [command]
-  (let [cmd (command-line command)
-        _ (println cmd)
+  [& arguments]
+  (let [cmd (conj (seq arguments) (git-exe))
         {:keys [exit out err]} (apply shell/sh cmd)]
     (if (zero? exit)
       (string/split-lines out)
@@ -39,20 +38,21 @@
 
 (defn- root-distance
   []
-  (count (git-command (format "rev-list HEAD"))))
+  (count (git-command "rev-list" "HEAD")))
 
 (defn- git-status []
-  (git-command "status -b --porcelain"))
+  (git-command "status" "-b" "--porcelain"))
 
 (defn- git-describe [prefix min-sha-length]
-  (git-command (format "describe --long --match '%s*.*' --abbrev=%d --dirty=-%s --always"
-                       prefix min-sha-length *dirty-mark*)))
+  (git-command "describe" "--long" "--match"
+               (str prefix "*.*")
+               (format "--abbrev=%d" min-sha-length)
+               (str "--dirty=-" *dirty-mark*)
+               "--always"))
 
 (defn tag [v & {:keys [prefix sign] :or {prefix *prefix* sign "--sign"}}]
-  (let []
-    (git-command
-     (string/join " " (filter identity ["tag" sign "--annotate"
-                                        "--message" "\"Automated lein-v release\"" (str prefix v)])))))
+  (apply git-command (filter identity ["tag" sign "--annotate"
+                                       "--message" "Automated lein-v release" (str prefix v)])))
 
 (defn version
   [& {:keys [prefix min-sha-length]

--- a/test/unit/leiningen/v/git.clj
+++ b/test/unit/leiningen/v/git.clj
@@ -12,7 +12,7 @@
 (fact "dirty repo is reflected in parsed git version"
       (version) => (just ["1.0.0" 27 "abcd" truthy])
       (provided
-       (#'leiningen.v.git/git-command (as-checker string?))
+       (#'leiningen.v.git/git-command & anything)
        => [(format "%s1.0.0-27-g%s-%s" "v" (subs "abcdef0123456789" 0 4) *dirty-mark*)]))
 
 (fact "git version is parsed with full (long) data"
@@ -22,17 +22,17 @@
 (fact "missing tag and fallback is parsed"
       (version) => (just [nil 2 "abcd" false])
       (provided
-       (#'leiningen.v.git/git-command #"describe.*")
+       (#'leiningen.v.git/git-command "describe" & anything)
        => [(format "%s" (subs "abcdef0123456789" 0 *min-sha-length*))]
-       (#'leiningen.v.git/git-command #"rev-list.*")
+       (#'leiningen.v.git/git-command "rev-list" & anything)
        => ["aec474649bf0fdfc399d8e7a03a70821ae96d0da" "8697630e04727fe81381941e2a6b3670795f98a7"]))
 
 (fact "dirty missing tag and fallback is parsed"
       (version) => (just [nil 2 "abcd" true])
       (provided
-       (#'leiningen.v.git/git-command #"describe.*")
+        (#'leiningen.v.git/git-command "describe" & anything)
        => [(format "%s-%s" (subs "abcdef0123456789" 0 *min-sha-length*) *dirty-mark*)]
-       (#'leiningen.v.git/git-command #"rev-list.*")
+       (#'leiningen.v.git/git-command "rev-list" & anything)
        => ["aec474649bf0fdfc399d8e7a03a70821ae96d0da" "8697630e04727fe81381941e2a6b3670795f98a7"]))
 
 (fact "uncommited or nonexistant repo error is handled"


### PR DESCRIPTION
Hi! This is an initial stab at adding Windows compatibility into lein-v and fixing #12.

This isn't really ready for merge yet, but I thought I'd check in about the general approach before I went further with it.

The root of the problem is that lein-v currently executes git by passing a long command to bash via `(shell/sh "/bin/bash" "-c" "git something --foo")`. Since Windows doesn't have a `/bin/bash`, the command fails.

This branch, as-is, gets `lein-v` mostly working on Windows and doesn't break Unix compatibility. What it does is to use the Windows `where` command (equivalent of `which` on Unix) to figure out where the `bash` executable is; then it splits up the command-line and essentially runs `(shell/sh "Path\\to\\git.exe" "something" "--foo")`.

It's a bit of a hack, though, and will likely fail with command-line arguments that are quoted in `lein-v` like the [commit messages](https://github.com/roomkey/lein-v/blob/master/src/leiningen/v/git.clj#L35). This is because it just runs `(string/split cmd #" +")` on the command-line for the Windows side.

The overall better approach would be to split up the strings representing various git command into lists of strings that could just be passed to `(shell/sh)` directly, so instead of `(git-command "status -b --porcelain")`, we'd have `(git-command ["status" "-b" "--porcelain"])`, or maybe the `& args` equivalent: `(git-command "status" "-b" "--porcelain")`.

With this approach, the only difference on the Windows and Unix side would hopefully be finding the path to the `git` executable. I'm happy to implement that in this PR, but it might be a somewhat large change so I thought I'd check first (also I'm not sure how much midje black magic I'd need to figure out to get the tests passing).