### PR TITLE
Adding support for string version of :lein-v in project.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ becomes this:
 
 Assuming that there is a git tag `v1.0.1` on the commit `HEAD~~`, and that the SHA of `HEAD` is uniquely identified by `abcd`.  This behavior is automatically enabled whenever lein-v finds the project version to be the keyword `:lein-v`.
 
+Note that the project version can be set to either the keyword `:lein-v` or the string `":lein-v"` (the Cursive IDE, in particular, gets confused by the keyword version).
+
 ## Dependencies
 
 In case you're using a monorepository, you could also use lein-v to determine the current version of dependencies.

--- a/src/lein_v/plugin.clj
+++ b/src/lein_v/plugin.clj
@@ -5,7 +5,7 @@
   (deploy-when-anchored))
 
 (defn- select-versioner [version]
-  (if (= :lein-v version)
+  (if (#{:lein-v ":lein-v"} version)
     version-from-scm
     (do (when (and (string? version) (or (empty? version) (re-find #"lein" version)))
           (leiningen.core.main/warn "WARNING: lein-v is not managing this project's version.  Set version in project.clj to :lein-v to trigger automatic lein-v management"))

--- a/test/integration/lein_v/plugin.clj
+++ b/test/integration/lein_v/plugin.clj
@@ -20,6 +20,17 @@
   => (contains {:version "0.0.0"
                :manifest (contains {"Implementation-Version" "0.0.0"})}))
 
+(fact "String version of :lein-v works correctly"
+      (against-background (before :facts (do (init!))))
+      (middleware {:version ":lein-v" :v {:from-scm 'leiningen.v.maven/from-scm}})
+      => (contains {:version "0.0.0"
+                    :manifest (contains {"Implementation-Version" "0.0.0"})}))
+
+(fact "Non :lein-v version number is ignored"
+      (against-background (before :facts (do (init!))))
+      (middleware {:version "1.2.3" :v {:from-scm 'leiningen.v.maven/from-scm}})
+      => (contains {:version "1.2.3"}))
+
 (fact "Baseless commit returns default + commit metadata"
   (against-background (before :facts (do (init!) (commit!))))
   (middleware $mproject)


### PR DESCRIPTION
Hi! Sorry to inundate you with pull requests. This is a small one that lets the user specify the version in project.clj either the keyword `:lein-v` (the existing behavior) or the string `":lein-v"`. The reason for this is that Cursive currently crashes when trying to import projects with their version numbers set to keywords.

I filed [a bug on the Cursive repo](https://github.com/cursive-ide/cursive/issues/1999) about the crashing issue, but I wouldn't be surprised if other tools that parse project.clj files from outside of leiningen also expect the version number to be a string, so it seems reasonable to support both `:lein-v` and `":lein-v"`.