### PR TITLE
Make sure the cache directory exists if necessary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # lein-v News -- history of user-visible changes
 
+## Unreleased
+
+* Ensure that the cache directory exists if necessary before trying to write to it
+
 ## 7.0.0 / 2018-12-17
 
 * Remove implicit hooks (add `abort-when-not-anchored` as required in aliases or deploy tasks)

--- a/src/leiningen/v/file.clj
+++ b/src/leiningen/v/file.clj
@@ -32,6 +32,7 @@
 (defn cache
   "Write the version of the given Leiningen project to a file-backed caches in different formats: clj (always written for backwards compatibility if no formats are provided), cljs, edn"
   [path version describe formats]
+  (clojure.java.io/make-parents path)
   (when (= 0 (count formats))
     (spit (str path "clj") (cache-source version describe)))
   (when (in? formats "clj") (spit (str path "clj") (cache-source version describe)))
@@ -39,4 +40,3 @@
   (when (in? formats "cljc") (spit (str path "cljc") (cache-source version describe)))
   (when (in? formats "cljx") (spit (str path "cljx") (cache-source version describe)))
   (when (in? formats "edn") (spit (str path "edn") (cache-edn-source version describe))))
-


### PR DESCRIPTION
My users were having trouble building [Beat Link Trigger](https://github.com/Deep-Symmetry/beat-link-trigger) from source, it was mysteriously crashing complaining about `version.edn` not existing, and it took a while to figure out why. That file is in my `.gitignore` because it is a build product, and I had no other files in the `resource/beat_link_trigger` directory, so git simply did not create that directory when someone cloned the project. Then `lein-v` failed to write the file because the necessary parent directories did not exist when it ran.

This one-liner should solve this problem in the future by creating the parent directories of the configured cache directory when necessary.