### PR TITLE
Fix multiple git executable in Windows problem

### DIFF
--- a/src/leiningen/v/git.clj
+++ b/src/leiningen/v/git.clj
@@ -20,7 +20,7 @@
          (lein/abort (format (str "Can't determine location of git.exe: 'where git.exe' returned %d.\n"
                                   "stdout: %s\n stderr: %s")
                              exit out err))
-         (string/trim out))))))
+         (string/trim (first (string/split-lines out))))))))
 
 (defn- git-exe []
   (if windows?

--- a/test/unit/leiningen/v/git.clj
+++ b/test/unit/leiningen/v/git.clj
@@ -67,3 +67,13 @@
       (push-tags) => ..whatever..
       (provided
        (#'leiningen.v.git/git-command "push" "--tags") => ..whatever..))
+
+
+(fact "push-tags invokes git correctly"
+      (#'leiningen.v.git/find-windows-git) => "1/git.exe"
+      (provided
+       (#'clojure.java.shell/sh "where.exe" "git.exe") => {:exit 0
+                                                           :out "    1/git.exe
+      2/git.exe
+3/somewhere/anotherfolder/git.exe"
+                                                           :err ""}))


### PR DESCRIPTION
In a situation with multiple git executables (git.exe) on the search
path, the underlying "where.exe" returns multiple matches in multiple
lines. This commit will fix the problem arising with this situation
where the git command to be called is this multi-line list. Instead, the
first git executable is returned find-windows-git.