### PR TITLE
Add ability to override dependency version flag value

### DIFF
--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -126,17 +126,18 @@
 ;;                          (.load pom-properties-reader)))]
 ;;   (get pom-properties "version"))
 
-(defn- update-dependency [v d]
-  (if-not (second d)
-    (assoc d 1 v)
-    d))
+(defn- update-dependency [project v d]
+  (let [lein-v-dep-flag (get-in project [:v :lein-v-dependency-flag])]
+    (if (= lein-v-dep-flag (second d))
+      (assoc d 1 v)
+      d)))
 
 (defn dependency-version-from-scm
   [project]
   (let [v (str (or (version (:v project)) "UNKNOWN"))]
     (clojure.core/update project
                          :dependencies
-                         #(map (partial update-dependency v) %1))))
+                         #(map (partial update-dependency project v) %1))))
 
 (defn add-workspace-data
   [project]

--- a/test/unit/leiningen/v.clj
+++ b/test/unit/leiningen/v.clj
@@ -14,6 +14,11 @@
                                        :dependencies [["abc" "1.0"]
                                                       ["def" nil]]))
 
+(def $project-with-lein-v-flag (-> $project
+                                   (assoc :dependencies [["abc" "1.0"]
+                                                         ["def" :lein-v]
+                                                         ["ghi" nil]])
+                                   (assoc-in [:v :lein-v-dependency-flag] :lein-v)))
 
 (defchecker as-string
   [expected]
@@ -36,6 +41,10 @@
       (:dependencies (dependency-version-from-scm $project-with-dependencies)) => (contains [["def" "[[0 0 0] nil 4 \"abcd\"]"]])
       (provided (git/version) => [nil 4 "abcd" false]))
 
+(fact "git version components are only injected into flagged dependencies when explicit lein-v version flag is specified"
+      (:dependencies (dependency-version-from-scm $project-with-lein-v-flag)) => (contains [["def" "[[1 2 3] nil 3 \"abcd\" true]"]
+                                                                                            ["ghi" nil]])
+      (provided (git/version) => ["[[1 2 3] nil]" 3 "abcd" true]))
 
 (fact "tag is created with updated version"
       (update $project :minor) => (as-string "[[1 3 0] nil]")


### PR DESCRIPTION
We're attempting to use `lein-v` alongside [lein-monolith](https://github.com/amperity/lein-monolith) in order to modularize the build process of a large monolithic repo. We found that when inheriting `:managed-depedencies` from the meta-project, leiningen's syntax for eliding dependency versions conflicted with the `nil` version syntax that `lein-v` looks for. As such, we couldn't find a clean way to specify some dependencies as "managed" while also specifying that some other dependencies have versions that are derived through the `dependency-version-from-scm` middleware.

The implementation approach here was informed by #5, allowing for an override value to be specified in the `:v` project map if desired, and gracefully falling back to the current default behavior if the override is not defined.

Please let me know if you'd like me to make any changes, or if there's a better way to accomplish the same goal.