### PR TITLE
Make prefix work properly when querying and updating version

### DIFF
--- a/src/leiningen/v.clj
+++ b/src/leiningen/v.clj
@@ -13,9 +13,9 @@
 
 (defn- version
   "Determine the version for the project by dynamically interrogating the environment"
-  [{from-scm :from-scm :or {from-scm 'leiningen.v.maven/from-scm}}]
+  [{from-scm :from-scm :or {from-scm 'leiningen.v.maven/from-scm} :as config}]
   (let [f (ns-resolve *ns* from-scm)
-        scm (git/version)]
+        scm (apply git/version (mapcat identity config))]
     (when-not scm (leiningen.core.main/warn "No SCM data available!"))
     (apply f scm)))
 


### PR DESCRIPTION
Using prefix in project.clj doesn't work properly:
```
{:v {:prefix "MYPREFIX-v"}}
```
The problem is that the prefix is only added when creating a tag, not checked when querying for current version or updating the version. This PR fixes that by forwarding the config (and thus, the prefix) to the code that checks the version.

Side note - I was not able to run any tests.